### PR TITLE
Fix latest version of pastec installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 MAINTAINER Michal Kurek <oki+github@md6.org>
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
-  && apt-get install -y curl wget vim libopencv-dev libmicrohttpd-dev libjsoncpp-dev cmake git
+  && apt-get install -y curl wget vim libopencv-dev libmicrohttpd-dev libjsoncpp-dev libcurl4-openssl-dev cmake git
 RUN git clone https://github.com/Visu4link/pastec.git /pastec
 RUN mkdir -p /pastec/build && mkdir /pastec/data
 WORKDIR /pastec/build
-RUN cmake ../ && make 
+RUN cmake ../ && make
 RUN cd /pastec/data \
   && wget http://pastec.io/files/visualWordsORB.tar.gz \
   && tar zxf visualWordsORB.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,18 @@ FROM ubuntu:18.04
 MAINTAINER Michal Kurek <oki+github@md6.org>
 
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update \
-  && apt-get install -y curl wget vim libopencv-dev libmicrohttpd-dev libjsoncpp-dev libcurl4-openssl-dev cmake git
+RUN apt-get update && \
+    apt-get install -y \
+    curl \
+    wget \
+    vim \
+    libopencv-dev \
+    libmicrohttpd-dev \
+    libjsoncpp-dev \
+    libcurl4-openssl-dev \
+    cmake \
+    git
+
 RUN git clone https://github.com/Visu4link/pastec.git /pastec
 RUN mkdir -p /pastec/build && mkdir /pastec/data
 WORKDIR /pastec/build
@@ -12,6 +22,9 @@ RUN cmake ../ && make
 RUN cd /pastec/data \
   && wget http://pastec.io/files/visualWordsORB.tar.gz \
   && tar zxf visualWordsORB.tar.gz
+
 EXPOSE 4212
+
 VOLUME /pastec/
+
 CMD ./pastec -p 4212 /pastec/data/visualWordsORB.dat

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,8 @@ RUN apt-get update && \
     apt-get install -y \
     curl \
     wget \
-    vim \
     libopencv-dev \
     libmicrohttpd-dev \
-    libjsoncpp-dev \
     libcurl4-openssl-dev \
     cmake \
     git


### PR DESCRIPTION
1) Upgraded the base image to ubuntu 18, it's the easiest way to install OpenCV 3.0 (The latest version of pastec requires it)

2) Removed unnecessary dependencies (they not required after upgrade + some of them were for debug purpose) and added required one;
